### PR TITLE
Add option to inline resources (--inline)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+.idea

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Version numbers of Shins aim to track the version of Slate they are compatible w
 * `npm install`
 * `node shins.js` or 
     * `node shins.js --minify` or
-	* `node shins.js --customcss`
+	* `node shins.js --customcss` or
+	* `node shins.js --inline`
 * To check locally: `node arapaho` and browse to [localhost:4567](http://localhost:4567) - changes to your source `.html.md` files will automatically be picked up and re-rendered
 * Add, commit and push
 * Then (in your fork) press this button
@@ -40,6 +41,7 @@ var shins = require('shins');
 var options = {};
 options.minify = false;
 options.customCss = false;
+options.inline = false;
 shins.render(markdownString, options, function(err, html) {
   // ...
 });
@@ -52,6 +54,7 @@ var shins = require('shins');
 var options = {};
 options.minify = false;
 options.customCss = false;
+options.inline = false;
 shins.render(markdownString, options)
 .then(html => {
   // ...
@@ -61,6 +64,8 @@ shins.render(markdownString, options)
 The `err` parameter is the result of the `ejs` rendering step.
 
 Setting `customCss` to `true` will include the `pub/css/screen_overrides.css`,`pub/css/print_overrides.css` and `pub/css/theme_override.css` files, in which you can override any of the default Slate theme, to save you from having to alter the main css files directly. This should make syncing up with future Shins / Slate releases easier.
+
+Setting `inline` to `true` will inline all page resources (except resources referenced via CSS, such as fonts) to output html. This way HTML can be used stand-alone, without needing any other resources. It will also set `minify` to `true`.
 
 ### Updating from Slate
 

--- a/index.js
+++ b/index.js
@@ -126,6 +126,9 @@ function render(inputStr, options, callback) {
         callback = options;
         options = {};
     }
+    if(options.inline == true) {
+        options.minify = true;
+    }
     return maybe(callback, new Promise(function (resolve, reject) {
         globalOptions = options;
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function render(inputStr, options, callback) {
         callback = options;
         options = {};
     }
-    if(options.inline == true) {
+    if (options.inline == true) {
         options.minify = true;
     }
     return maybe(callback, new Promise(function (resolve, reject) {
@@ -197,7 +197,7 @@ function render(inputStr, options, callback) {
         locals.partial = partial;
         locals.image_tag = function (image, altText, className) {
             var imageSource = "source/images/" + image;
-            if(globalOptions.inline) {
+            if (globalOptions.inline) {
                 var imgContent = fs.readFileSync(path.join(__dirname, imageSource));
                 imageSource = "data:image/png;base64,"+new Buffer(imgContent).toString('base64');
             }

--- a/shins.js
+++ b/shins.js
@@ -14,6 +14,10 @@ if (process.argv.length > 2) {
         if (opt.startsWith('--')) {
             if (opt == '--minify') options.minify = true;
             if (opt == '--customcss') options.customCss = true;
+            if (opt == '--inline') {
+                options.minify = true;
+                options.inline = true;
+            }
         }
         else {
             inputName = opt;

--- a/shins.js
+++ b/shins.js
@@ -14,10 +14,7 @@ if (process.argv.length > 2) {
         if (opt.startsWith('--')) {
             if (opt == '--minify') options.minify = true;
             if (opt == '--customcss') options.customCss = true;
-            if (opt == '--inline') {
-                options.minify = true;
-                options.inline = true;
-            }
+            if (opt == '--inline') options.inline = true;
         }
         else {
             inputName = opt;


### PR DESCRIPTION
It minifies and inlines images, javascript and css.
Only fonts are still loaded from external file.

This fixes https://github.com/Mermade/shins/issues/12, and makes it possible to use shins on read-only filesystem.