### PR TITLE
Updated margins on logo

### DIFF
--- a/pub/css/screen.css
+++ b/pub/css/screen.css
@@ -468,7 +468,7 @@ html, body {
   .toc-wrapper .logo {
     display: block;
     max-width: 100%;
-    margin-bottom: 0px; }
+    margin: 10px auto; }
   .toc-wrapper > .search {
     position: relative; }
     .toc-wrapper > .search input {

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -56,7 +56,7 @@ $lang-select-pressed-text: #fff !default; // color of language tab text when mou
 ////////////////////
 $nav-width: 230px !default; // width of the navbar
 $examples-width: 50% !default; // portion of the screen taken up by code examples
-$logo-margin: 0px !default; // margin below logo
+$logo-margin: 10px !default; // margin below logo
 $main-padding: 28px !default; // padding to left and right of content & examples
 $nav-padding: 15px !default; // padding to left and right of navbar
 $nav-v-padding: 10px !default; // padding used vertically around search boxes and results

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -75,7 +75,8 @@ html, body {
   .logo {
     display: block;
     max-width: 100%;
-    margin-bottom: $logo-margin;
+    margin: $logo-margin auto;
+
   }
 
   &>.search {


### PR DESCRIPTION
Logo's that aren't the size of the sidebar are left-aligned. Changed logo-margin variable to be 10px and set the left and right margins to auto to properly center it.