### PR TITLE
Add option to set custom logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Version numbers of Shins aim to track the version of Slate they are compatible w
 	* `node shins.js --customcss` or
 	* `node shins.js --inline` or
     * `node shins.js --unsafe`
+* To add custom logo add `--logo` option with path to your logo image.
 * To check locally: `node arapaho` and browse to [localhost:4567](http://localhost:4567) - changes to your source `.html.md` files and the `source/includes` directory will automatically be picked up and re-rendered. If you use `--launch` or `-l` your default browser will be opened automatically
 * Add, commit and push
 * Then (in your fork) press this button
@@ -72,6 +73,7 @@ options.customCss = false;
 options.inline = false;
 options.unsafe = false; // setting to true turns off markdown sanitisation
 //options.source = filename; // used to resolve relative paths for included files
+options.logo = './my-custom-logo.png'
 shins.render(markdownString, options)
 .then(html => {
   // ...
@@ -83,6 +85,8 @@ The `err` parameter is the result of the `ejs` rendering step.
 Setting `customCss` to `true` will include the `pub/css/screen_overrides.css`,`pub/css/print_overrides.css` and `pub/css/theme_override.css` files, in which you can override any of the default Slate theme, to save you from having to alter the main css files directly. This should make syncing up with future Shins / Slate releases easier.
 
 Setting `inline` to `true` will inline all page resources (except resources referenced via CSS, such as fonts) to output html. This way HTML can be used stand-alone, without needing any other resources. It will also set `minify` to `true`.
+
+Set `logo` path to add your custom logo as absolute path or path relative to process working directory. If `inline` option is on image will be inlined, else it will be copied to `source/images` directory and included via `scr`.
 
 ### Updating from Slate
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Setting `customCss` to `true` will include the `pub/css/screen_overrides.css`,`p
 
 Setting `inline` to `true` will inline all page resources (except resources referenced via CSS, such as fonts) to output html. This way HTML can be used stand-alone, without needing any other resources. It will also set `minify` to `true`.
 
-Set `logo` path to add your custom logo as absolute path or path relative to process working directory. If `inline` option is on image will be inlined, else it will be copied to `source/images` directory and included via `scr`.
+Set `logo` path to add your custom logo as absolute path or path relative to process working directory. If `inline` option is on image will be inlined, else it will be copied to `source/images` directory and included via `src` image attribute.
 
 ### Updating from Slate
 

--- a/index.js
+++ b/index.js
@@ -283,22 +283,22 @@ function render(inputStr, options, callback) {
             var imageSource = "source/images/" + image;
             if (globalOptions.inline) {
                 var imgContent = fs.readFileSync(path.join(__dirname, imageSource));
-                imageSource = "data:image/png;base64,"+new Buffer(imgContent).toString('base64');
+                imageSource = "data:image/png;base64," + Buffer.from(imgContent).toString('base64');
             }
             return '<img src="'+imageSource+'" class="' + className + '" alt="' + altText + '">';
         };
         locals.logo_image_tag = function () {
             if (!globalOptions.logo) return locals.image_tag('logo.png', 'Logo', 'logo');
-            var imageSource = path.resolve(process.cwd(), globalOptions.logo)
+            var imageSource = path.resolve(process.cwd(), globalOptions.logo);
             var imgContent = fs.readFileSync(imageSource);
             if (globalOptions.inline) {
-                imageSource = "data:image/png;base64,"+new Buffer(imgContent).toString('base64');
+                imageSource = "data:image/png;base64," + Buffer.from(imgContent).toString('base64');
             } else {
                 var logoPath = "source/images/custom_logo" + path.extname(imageSource);
                 fs.writeFileSync(path.join(__dirname, logoPath), imgContent);
                 imageSource = logoPath;
             }
-            return '<img src="'+imageSource+'" class="logo" alt="Logo">';
+            return '<img src="' + imageSource + '" class="logo" alt="Logo">';
         };
         locals.stylesheet_link_tag = stylesheet_link_tag;
         locals.javascript_include_tag = javascript_include_tag;

--- a/index.js
+++ b/index.js
@@ -287,6 +287,19 @@ function render(inputStr, options, callback) {
             }
             return '<img src="'+imageSource+'" class="' + className + '" alt="' + altText + '">';
         };
+        locals.logo_image_tag = function () {
+            if (!globalOptions.logo) return locals.image_tag('logo.png', 'Logo', 'logo');
+            var imageSource = path.join(process.cwd(), globalOptions.logo)
+            var imgContent = fs.readFileSync(imageSource);
+            if (globalOptions.inline) {
+                imageSource = "data:image/png;base64,"+new Buffer(imgContent).toString('base64');
+            } else {
+                var logoPath = "source/images/custom_logo.png";
+                fs.writeFileSync(logoPath, imgContent);
+                imageSource = logoPath;
+            }
+            return '<img src="'+imageSource+'" class="logo" alt="Logo">';
+        };
         locals.stylesheet_link_tag = stylesheet_link_tag;
         locals.javascript_include_tag = javascript_include_tag;
         locals.language_array = language_array;

--- a/index.js
+++ b/index.js
@@ -294,7 +294,7 @@ function render(inputStr, options, callback) {
             if (globalOptions.inline) {
                 imageSource = "data:image/png;base64,"+new Buffer(imgContent).toString('base64');
             } else {
-                var logoPath = "source/images/custom_logo.png";
+                var logoPath = "source/images/custom_logo" + path.extname(imageSource);
                 fs.writeFileSync(path.join(__dirname, logoPath), imgContent);
                 imageSource = logoPath;
             }

--- a/index.js
+++ b/index.js
@@ -289,13 +289,13 @@ function render(inputStr, options, callback) {
         };
         locals.logo_image_tag = function () {
             if (!globalOptions.logo) return locals.image_tag('logo.png', 'Logo', 'logo');
-            var imageSource = path.join(process.cwd(), globalOptions.logo)
+            var imageSource = path.resolve(process.cwd(), globalOptions.logo)
             var imgContent = fs.readFileSync(imageSource);
             if (globalOptions.inline) {
                 imageSource = "data:image/png;base64,"+new Buffer(imgContent).toString('base64');
             } else {
                 var logoPath = "source/images/custom_logo.png";
-                fs.writeFileSync(logoPath, imgContent);
+                fs.writeFileSync(path.join(__dirname, logoPath), imgContent);
                 imageSource = logoPath;
             }
             return '<img src="'+imageSource+'" class="logo" alt="Logo">';

--- a/source/layouts/layout.ejs
+++ b/source/layouts/layout.ejs
@@ -46,7 +46,7 @@ under the License.
       </span>
     </a>
     <div class="toc-wrapper">
-      <%- image_tag("logo.png", 'Logo', 'logo') %>
+      <%- logo_image_tag() %>
       <% if (language_tabs.length>0) {%>
         <div class="lang-selector">
           <% for (var lang in language_tabs) { %>


### PR DESCRIPTION
This PR solves part of the issue #27 by introducing `--logo` option.
Selected approach is:
- If `--inline` is `true` image is loaded and added as base64
- If `--inline` is `false` image file is copied to `source/images` directory with `custom-logo` filename to ease assets management and deployment.