### PR TITLE
Replace non-alphanumeric characters with dash in id attributes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,10 +165,19 @@ function preProcess(content,options) {
     return lines.join('\n');
 }
 
+function cleanId(id) {
+    return id.toLowerCase().replace(/\W/g, '-');
+}
+
 function postProcess(content) {
     // adds id a la GitHub autolinks to automatically-generated headers
-    content = content.replace(/\<(h[123456])\>(.*)\<\/h[123456]\>/g, function (match, group1, group2) {
-        return '<' + group1 + ' id="' + group2.toLowerCase().split(' ').join('-').split('/').join('-').split('.').join('-').split('(').join('-').split(')').join('-').split('[').join('-').split(']').join('-').split('?').join('-').split('&').join('-').split(';').join('-').split('{').join('-').split('}').join('-').split('=').join('-').split("'").join('-') + '">' + group2 + '</' + group1 + '>';
+    content = content.replace(/\<(h[123456])\>(.*)\<\/h[123456]\>/g, function (match, header, title) {
+        return '<' + header + ' id="' + cleanId(title) + '">' + title + '</' + header + '>';
+    });
+
+    // clean up the other ids as well
+    content = content.replace(/\<(h[123456]) id="(.*)"\>(.*)\<\/h[123456]\>/g, function (match, header, id, title) {
+        return '<' + header + ' id="' + cleanId(id) + '">' + title + '</' + header + '>';
     });
     return content;
 }


### PR DESCRIPTION
Although it is allowed to use just about any character for id attributes there are some that will create problems when using them from css or javascript/jquery. For shins it can be seen by adding f.ex. a "." to one of the ids in source/index.html.md. This PR cleans up the id attributes and replaces all non-alpanumeric character with a dash.

See discussion here: https://stackoverflow.com/a/79022