### PR TITLE
Add --no-links option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Version numbers of Shins aim to track the version of Slate they are compatible w
     * `node shins.js --minify` or
 	* `node shins.js --customcss` or
 	* `node shins.js --inline` or
-    * `node shins.js --unsafe`
+    * `node shins.js --unsafe` or
+    * `node shins.js --no-links`
 * To add custom logo add `--logo` option with path to your logo image.
 * To specify a different output filename from the default `./index.html`, use the `--output` or `-o` option.
 * To allow css-style attributes in markdown, specify the `--attr` option.
@@ -60,6 +61,7 @@ options.minify = false;
 options.customCss = false;
 options.inline = false;
 options.unsafe = false; // setting to true turns off markdown sanitisation
+options['no-links'] = false; // if true, do not automatically convert links in text to anchor tags
 //options.source = filename; // used to resolve relative paths for included files
 shins.render(markdownString, options, function(err, html) {
   // ...
@@ -76,6 +78,7 @@ options.minify = false;
 options.customCss = false;
 options.inline = false;
 options.unsafe = false; // setting to true turns off markdown sanitisation
+options['no-links'] = false; // if true, do not automatically convert links in text to anchor tags
 //options.source = filename; // used to resolve relative paths for included files
 options.logo = './my-custom-logo.png'
 shins.render(markdownString, options)

--- a/index.js
+++ b/index.js
@@ -218,6 +218,7 @@ function clean(s) {
 function render(inputStr, options, callback) {
 
     if (options.attr) md.use(attrs);
+    if (options.hasOwnProperty('no-links')) md.disable('linkify')
 
     if (typeof callback === 'undefined') { // for pre-v1.4.0 compatibility
         callback = options;

--- a/shins.js
+++ b/shins.js
@@ -31,6 +31,7 @@ if (options.help) {
     console.log('--minify    minify output html');
     console.log('-o,--output specify output html file');
     console.log('--unsafe    do not sanitise input markdown');
+    console.log('--no-links  do not automatically convert links in text to anchor tags');
     process.exit(0);
 }
 


### PR DESCRIPTION
We wanted to disable the automatic conversion of links to anchor tags, but there wasn't an option available to shins. Here we add a `--no-links` option which achieves our desired aim by disabling linkify. Please consider merging. If you want any changes made, let me know and I'll make them.