### PR TITLE
Files can now be included from other places than source/includes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,14 @@ function javascript_include_tag(include) {
 }
 
 function partial(include) {
-    var includeStr = safeReadFileSync(path.join(__dirname, '/source/includes/_' + include + '.md'), 'utf8');
+    var includePath = "";
+    if (include.indexOf("/") === 0) {
+        includePath = path.join(__dirname, include + '.md');
+    }
+    else {
+        includePath = path.join(__dirname, '/source/includes/_' + include + '.md');
+    }
+    var includeStr = safeReadFileSync(includePath, 'utf8');
     return postProcess(md.render(clean(includeStr)));
 }
 


### PR DESCRIPTION
Not sure if this is within the scope of Shins, but feel free to use it if you want!

This PR let's a user include files from other places than `source/includes` if the included file begins with a slash `/`. The files are included relative to the root shins path and doesn't have to begin with an underscore.

So it's now possible to include `file-a.md`, `file-b.md` and `file-c.md` from `shins/myfolder` like this;
```
---
title: MyAPI v1.0.0
includes:
  - /myfolder/file-a
  - /myfolder/file-b
  - /myfolder/file-c
---
```

If you use widdershins; `--includes '/myfolder/file-a,/myfolder/file-b,/myfolder/file-c'`.