### PR TITLE
Files can now be included from other places than source/includes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ $ api2html -o api.html api.yml
 * For converting [OpenAPI / Swagger](https://github.com/OAI/OpenAPI-Specification) or [AsyncAPI](https://github.com/asyncapi/asyncapi) definitions to Shins or Slate, see [widdershins](http://github.com/mermade/widdershins)
 * `arapaho` has a `--preserve` or `-p` option which will not overwrite your `.html` output file, but still re-render when necessary
 * Shins ships with an alternate theme by [TradeGecko](https://github.com/tradegecko) which is also under the Apache 2.0 license, `pub/css/tradegecko.min.css' can be included with the `--customcss` option
-* Shins additionally supports [AsciiDoc](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files) `include::filename[]` syntax as well as `!INCLUDE filename` from [markdown-pp](https://github.com/MikeRalphson/markdown-pp-js) - this is not supported by Slate
+* Shins additionally supports [AsciiDoc](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files) `include::filename[]` syntax as well as `!INCLUDE filename` from [markdown-pp](https://github.com/MikeRalphson/markdown-pp-js) - this is not supported by Slate. See some [more information about including files](/docs/include.md).
 
 ### Shins in the wild
 

--- a/docs/include.md
+++ b/docs/include.md
@@ -1,0 +1,33 @@
+# Including files
+
+Include content from separate markdown files either by using the `include::filename[]` or `!INCLUDE filename` syntax or by configuring them in the header of your markdown file.
+
+The configuration below will include the files `_file1.md`, `_file2.md` and `_file3.md` from the `/source/includes` path. (Please note that the files will have to begin with an `_` and end with a `.md` extension)
+
+```
+---
+title: MyAPI v1.0.0
+includes:
+  - file1
+  - file2
+  - file3
+---
+```
+
+If you wish to include files relative to the shins root path instead just begin the name with a `/`.
+
+The configuration below will include the files `file1.md`, `file2.md` and `file3.md` from `shins/myfolder`. (Please note that the files have to end with a `.md` extension)
+```
+---
+title: MyAPI v1.0.0
+includes:
+  - /myfolder/file1
+  - /myfolder/file2
+  - /myfolder/file3
+---
+```
+
+The same example if you include files using [widdershins](https://github.com/Mermade/widdershins/).
+```
+--includes '/myfolder/file1,/myfolder/file2,/myfolder/file3'
+```

--- a/index.js
+++ b/index.js
@@ -77,7 +77,14 @@ function javascript_include_tag(include) {
 }
 
 function partial(include) {
-    var includeStr = safeReadFileSync(path.join(__dirname, '/source/includes/_' + include + '.md'), 'utf8');
+    var includePath = "";
+    if (include.indexOf("/") === 0) {
+        includePath = path.join(__dirname, include + '.md');
+    }
+    else {
+        includePath = path.join(__dirname, '/source/includes/_' + include + '.md');
+    }
+    var includeStr = safeReadFileSync(includePath, 'utf8');
     return postProcess(md.render(clean(includeStr)));
 }
 


### PR DESCRIPTION
Take 2. ;)
Not sure if this is within the scope of Shins, but feel free to use it if you want!

This PR let's a user include files from other places than `source/includes` if the included file begins with a slash `/`. The files are included relative to the root shins path and doesn't have to begin with an underscore.

So it's now possible to include `file-a.md`, `file-b.md` and `file-c.md` from `shins/myfolder` like this;
```
---
title: MyAPI v1.0.0
includes:
  - /myfolder/file-a
  - /myfolder/file-b
  - /myfolder/file-c
---
```

If you use widdershins; `--includes '/myfolder/file-a,/myfolder/file-b,/myfolder/file-c'`.