### PR TITLE
Shutterstock is using Shins for its public API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ Please feel free to add a link to your API documentation here
 * [APIs.guru OpenAPI specification extensions (Semoasa) documentation](https://mermade.github.io/shins/apisguru.html)
 * [Signal Biometrics Ox documentation](https://signalbiometrics.github.io/ox-docs/)
 * [LeApp daemon API](https://leapp-to.github.io/shins/index.html)
+* [Shutterstock API](https://api-reference.shutterstock.com/)


### PR DESCRIPTION
Thanks for providing Shins!

https://api-reference.shutterstock.com/