### PR TITLE
keep classes in table tags when sanitizing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,8 @@ function clean(s) {
         allowedAttributes: { a: [ 'href', 'id', 'name', 'target', 'class' ], img: [ 'src', 'alt', 'class' ] , aside: [ 'class' ],
             abbr: [ 'title', 'class' ], details: [ 'open', 'class' ], div: [ 'class' ], meta: [ 'name', 'content' ],
             link: [ 'rel', 'href', 'type', 'sizes' ],
-            h1: [ 'id' ], h2: [ 'id' ], h3: [ 'id' ], h4: [ 'id' ], h5: [ 'id' ], h6: [ 'id' ]}
+            h1: [ 'id' ], h2: [ 'id' ], h3: [ 'id' ], h4: [ 'id' ], h5: [ 'id' ], h6: [ 'id' ],
+            table: [ 'class' ], tr: [ 'class' ], td: [ 'class' ]}
     };
     // replace things which look like tags which sanitizeHtml will eat
     s = s.split('\n>').join('\n$1$');


### PR DESCRIPTION
This is my first open source PR, so please excuse me if I did anything wrong.

I have a use case in which I would like to create a table in my .md file using html tags with classes. The code currently sanitizes away my classes.

(I am creating this table using html instead of markdown because I would like it to have collapsable and expandable rows.)