### PR TITLE
Add the request type to TOC links

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,7 +320,18 @@ function render(inputStr, options, callback) {
                     
                     // Find next "<code>" block and pull out the type
                     let route = $($(this).nextUntil ("h2", "p").find ("code")[0]).text ();
-                    child.type = (route || "").split (" ")[0];
+					child.type = (route || "").split (" ")[0] || "";
+					switch (child.type.toLowerCase ()) {
+						case "get":
+						case "post":
+						case "delete":
+						case "put":
+						case "patch":
+							break;
+						default:
+							child.type = "";
+							break;
+					}
 
                     h2 = child;
                     if (h1) h1.children.push(child);

--- a/index.js
+++ b/index.js
@@ -317,6 +317,11 @@ function render(inputStr, options, callback) {
                     child.id = $(this).attr('id');
                     child.content = $(this).text();
                     child.children = [];
+                    
+                    // Find next "<code>" block and pull out the type
+                    let route = $($(this).nextUntil ("h2", "p").find ("code")[0]).text ();
+                    child.type = (route || "").split (" ")[0];
+
                     h2 = child;
                     if (h1) h1.children.push(child);
                 }
@@ -351,7 +356,7 @@ function render(inputStr, options, callback) {
                     if (h5) h5.children.push(child);
                 }
             });
-            return result; //[{id:'test',content:'hello',children:[]}];
+            return result; //[{id:'test',content:'hello',type:'GET',children:[]}];
         };
         locals.partial = partial;
         locals.image_tag = function (image, altText, className) {

--- a/source/layouts/layout.ejs
+++ b/source/layouts/layout.ejs
@@ -73,7 +73,7 @@ under the License.
               <ul class="toc-list-h2">
                 <% for (var h2 of h1.children) { %>
                   <li>
-                    <a href="#<%= h2.id %>" class="toc-h2 toc-link" data-title="<%= h2.content %>"><%= h2.content %></a>
+                    <a href="#<%= h2.id %>" class="toc-h2 toc-link" data-type="<%= h2.type %>" data-title="<%= h2.content %>"><%= h2.content %></a>
                     <% if (h2.children && (h2.children.length > 0)) { %>
                       <ul class="toc-list-h3">
                       <% for (var h3 of h2.children) { %>


### PR DESCRIPTION
This commit finds the next `<code>` tag following an H2 and parses out the request type (GET, POST, PUT, DELETE, etc). This can be used to add extra styling:

![image](https://user-images.githubusercontent.com/4183007/55745538-7c676d00-5a05-11e9-9821-fc044d819fc6.png)
