### PR TITLE
Recursive watch for arapaho

### DIFF
--- a/arapaho.js
+++ b/arapaho.js
@@ -30,7 +30,7 @@ app.use(compression());
 app.set('view engine', 'html');
 app.engine('html', ejs.renderFile);
 
-fs.watch('source/includes', function(eventType, filename) {
+fs.watch('source/includes', { recursive: true }, function(eventType, filename) {
     includesModified = true;
 });
 


### PR DESCRIPTION
This solves issue #67.

The goal of this PR is to make the watch on the includes folder be recursive, so that changes to nested includes will also be picked up.