### PR TITLE
Implemented regex fix to prevent ToC adding HTML tags to document title with deeper levels of nesting

### DIFF
--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -80,9 +80,9 @@
         if (window.history.replaceState) {
           window.history.replaceState(null, "", best);
         }
-        var thisTitle = $best.data("title").replace(htmlPattern, "");
+        var thisTitle = $best.data("title");
         if (thisTitle !== undefined && thisTitle.length > 0) {
-          document.title = thisTitle + " – " + originalTitle;
+          document.title = thisTitle.replace(htmlPattern, "") + " – " + originalTitle;
         } else {
           document.title = originalTitle;
         }

--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -80,7 +80,7 @@
         if (window.history.replaceState) {
           window.history.replaceState(null, "", best);
         }
-        var thisTitle = $best.data("title")
+        var thisTitle = $best.data("title").replace(htmlPattern, "");
         if (thisTitle !== undefined && thisTitle.length > 0) {
           document.title = thisTitle + " – " + originalTitle;
         } else {


### PR DESCRIPTION
**Use case**: 

My organization added more deeply nested levels. This caused an issue where the ToC library would grab the HTML tags surrounding the current level and add those into the `document.title`, giving us such titles in our browser window like:
 `<strong><em>GET endpointName by field</strong></em> - MyOrganization's API`.

**Fix**:

It's an issue that I've already [submitted a PR fix to Slate](https://github.com/lord/slate/issues/1119), but it looks like Slate is somewhat stale with the last commit being over 2 months ago, so I thought you might want it downstream first.

I wrote a regex to fix the issue, and right after pushing it, I noticed there was an identical & unused regexp named `htmlPattern` at the top of the library, which I assume was meant to be used to prevent this issue but was never fully implemented.