### PR TITLE
Add Shotstack to in the wild list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,5 @@ Please feel free to add a link to your API documentation here
 * [Signal Biometrics Ox documentation](https://signalbiometrics.github.io/ox-docs/)
 * [LeApp daemon API](https://leapp-to.github.io/shins/index.html)
 * [Shutterstock API](https://api-reference.shutterstock.com/)
+* [Shotstack Video Editing API](https://shotstack.io/docs/api/index.html)
+


### PR DESCRIPTION
Added our link on the Widdershins project just now, we've done a some customisation to our design, users can see it here: https://github.com/shotstack/oas-api-definition. Hope you can add us to your list and share our our integration for others to reference.

