### PR TITLE
Add handler for `opn` function call

### DIFF
--- a/arapaho.js
+++ b/arapaho.js
@@ -111,6 +111,11 @@ var server = app.listen(myport, function () {
   console.log('Arapaho server listening at http://%s:%s', host, port);
   if (args.launch) {
     console.log('Launching...');
-    opn('http://'+(host === '::' ? 'localhost' : 'host') + ':' +port+'/');
+
+    var url = 'http://'+(host === '::' ? 'localhost' : 'host') + ':' +port+'/'
+    opn(url).catch(function (ex) {
+        console.error(`Unable to open URL '${url}'`);
+        console.error(ex);
+    })
   }
 });


### PR DESCRIPTION
Hi there,

Thanks for your work on this project, it's been really great to get up and going with a really neat looking set of docs!

Came across an unhandled exception when running the app inside docker for the first time, I was running `npm start` which includes the `-l` flag for arapaho, which won't work in the container I'm running.

```
docs             | > node arapaho -l
docs             |
docs             | Arapaho server listening at http://:::4567
docs             | Launching...
docs             | (node:112) UnhandledPromiseRejectionWarning: Error: Exited with code 3
docs             |     at ChildProcess.<anonymous> (/app/nankai/shins/node_modules/opn/index.js:84:13)
docs             |     at Object.onceWrapper (events.js:300:26)
docs             |     at ChildProcess.emit (events.js:210:5)
docs             |     at maybeClose (internal/child_process.js:1021:16)
docs             |     at Socket.<anonymous> (internal/child_process.js:430:11)
docs             |     at Socket.emit (events.js:210:5)
docs             |     at Pipe.<anonymous> (net.js:659:12)
docs             | (node:112) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
docs             | (node:112) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

It looks like the convention across the app is try/catch, however that didn't work with the `opn` function call, so I used the `.catch` syntax instead.