### PR TITLE
Backport for JQuery CVE-2019-11358 patch

### DIFF
--- a/source/javascripts/lib/_jquery.js
+++ b/source/javascripts/lib/_jquery.js
@@ -229,8 +229,10 @@ jQuery.extend = jQuery.fn.extend = function() {
 				src = target[ name ];
 				copy = options[ name ];
 
+                // From https://github.com/DanielRuf/snyk-js-jquery-174006/blob/master/jquery-2.2.4.patch
+                // Prevent Object.prototype pollution
 				// Prevent never-ending loop
-				if ( target === copy ) {
+				if ( name === "__proto__" || target === copy ) {
 					continue;
 				}
 


### PR DESCRIPTION
Taken from:  https://github.com/DanielRuf/snyk-js-jquery-174006/blob/master/jquery-2.2.4.patch

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

**Note: development on Shins has paused. Please see the [Slate v3 Technology Preview](https://github.com/slatedocs/slate/discussions/1271) for where Slate or Shins is headed next.**

-->
